### PR TITLE
feat(peakfinder): add algorithm for finding a peak in a 1d list

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,3 +1,3 @@
 (set-env!
  :resource-paths #{"src"}
- :dependencies '[[org.clojure/tools.trace "0.7.9"]])
+ :dependencies '[[org.clojure/core.match "0.3.0-alpha4"]])

--- a/src/peak_finding/1d_list.clj
+++ b/src/peak_finding/1d_list.clj
@@ -1,0 +1,77 @@
+;; A peak is any element that is larger or equal to both it's neighbours
+;; Items that only have one neighbour (end items) are considered a peak if
+;; they are larger or equal to their neighbour
+;; This algorithm returns the first peak it finds.
+
+(ns peakfinder)
+
+(defn- item
+  "returns a map that represents an item in a list. The data describes the
+  index at which the item resides in the sequence and it's value. e.g. {index 1 :value 3}"
+  [sequence, index]
+  {:index index :value (nth sequence index nil)})
+
+(defn- right-neighbour
+  "returns the right neighbour of an item in a sequence"
+  [sequence current-item]
+  (item sequence (inc (:index current-item))))
+
+(defn- left-neighbour
+  "returns the left neighbour of an item in a sequence"
+  [sequence current-item]
+  (item sequence (dec (:index current-item))))
+
+(defn- peak?
+  "determines if an item is a peak compared to the supplied comparitors"
+  [item & comparitors]
+  (let [item-value (:value item)
+        values (map :value comparitors)]
+    (if (every? (fn [v] (>= item-value v)) values) item-value -1)))
+
+(defn- middle-val
+  "returns the middle value of a sequence"
+  [sequence]
+  (-> (count sequence) (- 1) (/ 2) (int)))
+
+(defn find-peak
+  "multiple arity recursive function, for finding a peak in a sequence"
+  ([sequence] (->> (middle-val sequence) (item sequence) (find-peak sequence)))
+
+  ([sequence current-item]
+   (if (empty? sequence) -1
+       (let [index (:index current-item)
+             left (left-neighbour sequence current-item)
+             right (right-neighbour sequence current-item)]
+         (cond
+           (-> sequence (count) (- 1) (= index)) ;; Furthest item right
+           (peak? current-item left)
+
+           (= index 0) ;; Furthest item left
+           (peak? current-item right)
+
+           :else
+           (if (= (peak? current-item left right) -1)
+
+             (if (> (:value left) (:value current-item))
+               (find-peak sequence left) ;; Recursive
+               (find-peak sequence right)) ;; Recursive
+
+             (:value current-item)))))))
+
+
+;; Unit tests
+(ns peakfinder-test
+  (:use clojure.test)
+  (:use peakfinder))
+
+(deftest finding-a-peak
+  (is (contains? #{7} (find-peak [3 2 4 7 5 6 2])))
+  (is (contains? #{3} (find-peak [3 2 1])))
+  (is (contains? #{3 4 6} (find-peak [3 2 4 3 5 6 2])))
+  (is (contains? #{3 6} (find-peak [3 2 0 1 2 6 2])))
+  (is (contains? #{3 4} (find-peak [3 2 1 4])))
+  (is (contains? #{3} (find-peak [1 3 2 1])))
+  (is (contains? #{3 2} (find-peak [3 3 2 2])))
+  (is (contains? #{-1} (find-peak []))))
+
+(run-tests 'peakfinder-test)

--- a/src/peak_finding/1d_list.clj
+++ b/src/peak_finding/1d_list.clj
@@ -1,63 +1,34 @@
 ;; A peak is any element that is larger or equal to both it's neighbours
 ;; Items that only have one neighbour (end items) are considered a peak if
 ;; they are larger or equal to their neighbour
-;; This algorithm returns the first peak it finds.
 
-(ns peakfinder)
+(ns peakfinder
+  (:require [clojure.core.match :refer [match]]))
 
-(defn- item
-  "returns a map that represents an item in a list. The data describes the
-  index at which the item resides in the sequence and it's value. e.g. {index 1 :value 3}"
-  [sequence, index]
-  {:index index :value (nth sequence index nil)})
+(defn find-peak [input]
+  "Returns all peaks in a sequence"
+  (match [input]
+         ;; checks input is a sequence of multiple numbers
+         [(input :guard #(and (sequential? %)
+                              (> (count %) 1)
+                              (every? number? %)))]
+         (let [all-nums (cons 0 input) ;; adds a zero to the head
+               groups (partition 3 1 [0] all-nums)] ;; pads a zero to the tail
+           (reduce (fn [memo group]
+                     (let [middle (second group)]
+                       (if (= (apply max group) middle)
+                         (conj memo middle)
+                         memo)))
+                   []
+                   groups))
 
-(defn- right-neighbour
-  "returns the right neighbour of an item in a sequence"
-  [sequence current-item]
-  (item sequence (inc (:index current-item))))
+         ;; checks input contains head only
+         [([h] :seq)]
+         input
 
-(defn- left-neighbour
-  "returns the left neighbour of an item in a sequence"
-  [sequence current-item]
-  (item sequence (dec (:index current-item))))
-
-(defn- peak?
-  "determines if an item is a peak compared to the supplied comparitors"
-  [item & comparitors]
-  (let [item-value (:value item)
-        values (map :value comparitors)]
-    (if (every? (fn [v] (>= item-value v)) values) item-value -1)))
-
-(defn- middle-val
-  "returns the middle value of a sequence"
-  [sequence]
-  (-> (count sequence) (- 1) (/ 2) (int)))
-
-(defn find-peak
-  "multiple arity recursive function, for finding a peak in a sequence"
-  ([sequence] (->> (middle-val sequence) (item sequence) (find-peak sequence)))
-
-  ([sequence current-item]
-   (if (empty? sequence) -1
-       (let [index (:index current-item)
-             left (left-neighbour sequence current-item)
-             right (right-neighbour sequence current-item)]
-         (cond
-           (-> sequence (count) (- 1) (= index)) ;; Furthest item right
-           (peak? current-item left)
-
-           (= index 0) ;; Furthest item left
-           (peak? current-item right)
-
-           :else
-           (if (= (peak? current-item left right) -1)
-
-             (if (> (:value left) (:value current-item))
-               (find-peak sequence left) ;; Recursive
-               (find-peak sequence right)) ;; Recursive
-
-             (:value current-item)))))))
-
+         ;; other input
+         :else
+          nil))
 
 ;; Unit tests
 (ns peakfinder-test
@@ -65,13 +36,18 @@
   (:use peakfinder))
 
 (deftest finding-a-peak
-  (is (contains? #{7} (find-peak [3 2 4 7 5 6 2])))
-  (is (contains? #{3} (find-peak [3 2 1])))
-  (is (contains? #{3 4 6} (find-peak [3 2 4 3 5 6 2])))
-  (is (contains? #{3 6} (find-peak [3 2 0 1 2 6 2])))
-  (is (contains? #{3 4} (find-peak [3 2 1 4])))
-  (is (contains? #{3} (find-peak [1 3 2 1])))
-  (is (contains? #{3 2} (find-peak [3 3 2 2])))
-  (is (contains? #{-1} (find-peak []))))
+  (is (= [3 7 6] (find-peak [3 2 4 7 5 6 2])))
+  (is (= [3] (find-peak '(3 2 1))))
+  (is (= [3 4 6] (find-peak [3 2 4 3 5 6 2])))
+  (is (= [3 6] (find-peak '(3 2 0 1 2 6 2))))
+  (is (= [3 4] (find-peak [3 2 1 4])))
+  (is (= [3] (find-peak '(1 3 2 1))))
+  (is (= [3 3 2] (find-peak [3 3 2 2])))
+  (is (= [3] (find-peak [3])))
+  (is (= [3] (find-peak [3 1])))
+  (is (= nil (find-peak "random")))
+  (is (= nil (find-peak 3)))
+  (is (= nil (find-peak [])))
+  (is (= nil (find-peak '()))))
 
 (run-tests 'peakfinder-test)


### PR DESCRIPTION
This PR adds a Peakfinder algorithm example.

A peak is any element in a list that is larger or equal to both it's neighbours
Items that only have one neighbour (end items) are considered a peak if
they are larger or equal to their neighbour.
